### PR TITLE
fix: 캘린더 선택 오류 수정

### DIFF
--- a/static/js/reservation.js
+++ b/static/js/reservation.js
@@ -42,10 +42,10 @@ function renderCalendar() {
             currentMonth === new Date().getMonth() &&
             currentYear === new Date().getFullYear()
         ) {
-            days += `<div class="day today">${i}</div>`;
+            days += `<div class="day cur today">${i}</div>`;
         } else {
             // else "today" 클래스 추가 안함
-            days += `<div class="day">${i}</div>`;
+            days += `<div class="day cur">${i}</div>`;
         }
     }
 
@@ -85,7 +85,7 @@ function goToday() {
 }
 
 function selectDay(selectYear, selectMonth) {
-    const allDays = document.querySelectorAll(".days .day");
+    const allDays = document.querySelectorAll(".days .day.cur");
     const yearMonth = selectYear + "-" + (selectMonth + 1);
     allDays.forEach(function (day) {
         day.addEventListener("click", function () {


### PR DESCRIPTION
## #️⃣ Issue 번호
close #38

<br />

## 🔘 Part
- [x] FE
- [ ] BE
- [ ] 기타

<br />

## 🛠 작업 내용
현재 캘린더의 활성화 되어있지 않은 
이전 달, 다음 달 날짜 선택 시 색 변경되지 않도록 수정했습니다.
<br />

## 🎻 이미지 첨부 및 comment (선택)

<br />
