### PR TITLE
feat: "로그인 | 회원가입", "마이페이지" 버튼 추가 & 로고 로그인 후 처리

### DIFF
--- a/static/css/header.css
+++ b/static/css/header.css
@@ -1,0 +1,48 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+}
+
+.headerContainer {
+    background-color: #e7ffe8;
+    padding-bottom: 10px;
+    display: flex;
+    justify-content: space-between;
+}
+
+.menuList {
+    display: flex;
+    margin-left: 15rem;
+    gap: 30px;
+}
+
+.aTag {
+    display: flex;
+    align-items: end;
+    gap: 15px;
+    margin-bottom: 5px;
+}
+
+.aTag,
+a {
+    text-decoration: none;
+    color: black;
+    font-weight: bold;
+}
+
+.logout {
+    display: flex;
+    align-items: end;
+    margin-right: 15rem;
+    gap: 6px;
+}
+
+.logout button {
+    border: none;
+    background-color: #6fc274;
+    color: white;
+    border-radius: 5px;
+    font-weight: 700;
+    padding: 8px;
+    cursor: pointer;
+}

--- a/static/js/header.js
+++ b/static/js/header.js
@@ -1,6 +1,16 @@
 const form = document.forms["form_logout"];
 
-function logout() {
+document.addEventListener("click", (e) => {
+    if (!e.target.classList.contains("login-btn")) return;
+    document.location.href = "/user";
+});
+document.addEventListener("click", (e) => {
+    if (!e.target.classList.contains("mypage-btn")) return;
+    document.location.href = "/profile";
+});
+
+document.addEventListener("click", (e) => {
+    if (!e.target.classList.contains("logout-btn")) return;
     axios({
         method: "post",
         url: "/user/logout",
@@ -16,4 +26,4 @@ function logout() {
         .catch((err) => {
             alert("잘못된 요청입니다. 다시 시도해주세요.");
         });
-}
+});

--- a/views/include/header.ejs
+++ b/views/include/header.ejs
@@ -1,64 +1,15 @@
 <!doctype html>
 <html lang="en">
-    <style>
-        
-        .wrapper {
-            display: flex;
-            flex-direction: column;
-        }
-        
-        .headerContainer {
-           background-color: #E7FFE8;
-            padding-bottom: 10px;
-            display: flex;
-            justify-content: space-between;
-        }
-
-        .menuList {
-            display: flex;
-            margin-left: 15rem;
-            gap: 30px;
-        }
-
-        .aTag {
-            display: flex;
-            align-items: end;
-            gap: 15px;
-            margin-bottom: 5px;
-        }
-
-        .aTag,
-        a {
-            text-decoration: none;
-            color: black;
-            font-weight: bold;
-        }
-
-        .logout {
-            display: flex;
-            align-items: end;
-            margin-right: 15rem;
-            
-        }
-
-        .logout button {
-            border: none;
-            background-color: #6FC274;
-            color: white;
-            border-radius: 5px;
-            font-weight: 700;
-            padding: 8px;
-            cursor: pointer;
-        }
-
-
-    </style>
-
+<link rel="stylesheet" href="/static/css/header.css">
     <body>
         <div class=".wrapper">
             <div class="headerContainer">
                 <div class="menuList">
+                    <%if(session && session.u_id){%>
+                        <a href="/reservation">
+                    <%} else {%>
                         <a href="/user">
+                    <%}%>
                             <img
                             src="/static/images/logo&title.png"
                             alt="sesachub image"
@@ -71,11 +22,14 @@
                         </div>
                 </div>
                 <div class="logout">
-                    <%if(session && session.u_id) {%>
-                    <button type="button" onclick="logout()">로그아웃</button>
-                    <%}%>
+                     <%if(session && session.u_id) {%>
+                        <button type="button" class="mypage-btn">마이페이지</button>
+                        <button type="button" class="logout-btn">로그아웃</button>
+                     <%} else {%>
+                        <button type="button" class="login-btn">로그인 &nbsp; | &nbsp; 회원가입</button>
+                     <%}%>
                 </div>
             </div>
-            <script src="/static/js/logout.js"></script>
+            <script src="/static/js/header.js"></script>
     </body>
 </html>


### PR DESCRIPTION
## #️⃣ Issue 번호
close #56

<br />

## 🔘 Part
- [x] FE
- [ ] BE
- [ ] 기타

<br />

## 🛠 작업 내용
- 로그인 전 
    -  "로그인 | 회원가입" 버튼 표시되게 구현
- 로그인 후
    - "마이페이지" 버튼 추가
    - 로고 클릭 시 로그인 페이지로 이동했던 것을 **예약하기 페이지**로 이동
<br />

## 🎻 이미지 첨부 및 comment (선택)

### 로그인 전
![image](https://github.com/sabb12/sesachub/assets/125553827/77d09297-b2ee-4719-a7a9-b3ee8788dbab)


### 로그인 후
![image](https://github.com/sabb12/sesachub/assets/125553827/82125cec-c248-4f15-8396-655ca41dabcc)

<br />
